### PR TITLE
explicitly enable scripts in the WebView

### DIFF
--- a/src/BirdseyeContentProvider.ts
+++ b/src/BirdseyeContentProvider.ts
@@ -14,7 +14,9 @@ export default class BirdseyeContentProvider {
     }
 
     start(){
-        this.panel = vscode.window.createWebviewPanel("birdseye","birdseye", vscode.ViewColumn.Two);
+        this.panel = vscode.window.createWebviewPanel("birdseye", "birdseye", vscode.ViewColumn.Two, {
+            enableScripts: true,
+        });
         this.panel.webview.html = "Starting birdseye..."
         return this.panel;
     }


### PR DESCRIPTION
It seems like at some point since this commit, scripts in WebViews went from implicitly allowed to implicitly disabled, so this will let birdseye do its magic again